### PR TITLE
Add unit tests for get_parts function

### DIFF
--- a/backend/parts/test_app.py
+++ b/backend/parts/test_app.py
@@ -51,5 +51,87 @@ class TestPartsAPI(unittest.TestCase):
         self.assertEqual(data['weight'], 0.1)
         self.assertEqual(data['price'], 299.99)
 
+@patch('app.get_part_repository')
+    def test_get_parts_returns_correct_data(self, mock_get_part_repository):
+        mock_repo = MagicMock()
+        mock_get_part_repository.return_value = mock_repo
+
+        mock_part = MagicMock()
+        mock_part.id = 1
+        mock_part.name = "Test CPU"
+        mock_part.delivery_time = "5 days"
+        mock_part.weight = 0.1
+        mock_part.price = 299.99
+        mock_part.source_location.id = 1
+        mock_part.source_location.name = "Test Factory"
+        mock_part.source_location.latitude = 0.0
+        mock_part.source_location.longitude = 0.0
+        mock_part.suppliers = []
+
+        mock_repo.get_all_parts.return_value = [mock_part]
+
+        response = self.app.get('/api/parts')
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['id'], 1)
+        self.assertEqual(data[0]['name'], "Test CPU")
+        self.assertEqual(data[0]['deliveryTime'], "5 days")
+        self.assertEqual(data[0]['weight'], 0.1)
+        self.assertEqual(data[0]['price'], 299.99)
+        self.assertEqual(data[0]['sourceLocation']['id'], 1)
+        self.assertEqual(data[0]['sourceLocation']['name'], "Test Factory")
+        self.assertEqual(data[0]['sourceLocation']['latitude'], 0.0)
+        self.assertEqual(data[0]['sourceLocation']['longitude'], 0.0)
+        self.assertEqual(data[0]['suppliers'], [])
+
+    @patch('app.get_part_repository')
+    def test_get_part_returns_correct_data(self, mock_get_part_repository):
+        mock_repo = MagicMock()
+        mock_get_part_repository.return_value = mock_repo
+
+        mock_part = MagicMock()
+        mock_part.id = 1
+        mock_part.name = "Test CPU"
+        mock_part.delivery_time = "5 days"
+        mock_part.weight = 0.1
+        mock_part.price = 299.99
+        mock_part.source_location.id = 1
+        mock_part.source_location.name = "Test Factory"
+        mock_part.source_location.latitude = 0.0
+        mock_part.source_location.longitude = 0.0
+        mock_part.suppliers = []
+
+        mock_repo.get_part.return_value = mock_part
+
+        response = self.app.get('/api/parts/1')
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['id'], 1)
+        self.assertEqual(data['name'], "Test CPU")
+        self.assertEqual(data['deliveryTime'], "5 days")
+        self.assertEqual(data['weight'], 0.1)
+        self.assertEqual(data['price'], 299.99)
+        self.assertEqual(data['sourceLocation']['id'], 1)
+        self.assertEqual(data['sourceLocation']['name'], "Test Factory")
+        self.assertEqual(data['sourceLocation']['latitude'], 0.0)
+        self.assertEqual(data['sourceLocation']['longitude'], 0.0)
+        self.assertEqual(data['suppliers'], [])
+
+    @patch('app.get_part_repository')
+    def test_get_part_returns_404_for_nonexistent_part(self, mock_get_part_repository):
+        mock_repo = MagicMock()
+        mock_get_part_repository.return_value = mock_repo
+
+        mock_repo.get_part.return_value = None
+
+        response = self.app.get('/api/parts/999')
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(data['error'], 'Part not found')
+
 if __name__ == '__main__':
     unittest.main() 


### PR DESCRIPTION
This PR adds unit tests for the get_parts function in backend/parts/app.py. The tests cover the following scenarios:
- Retrieving all parts successfully
- Retrieving a specific part successfully
- Handling the case where a part does not exist

The tests use mocking to isolate the function being tested and ensure that the tests are reliable and fast.