### PR TITLE
Add Cypress E2E test for product navigation

### DIFF
--- a/frontend/cypress/e2e/product-navigation.cy.ts
+++ b/frontend/cypress/e2e/product-navigation.cy.ts
@@ -1,0 +1,20 @@
+describe('Product Navigation', () => {
+  it('should navigate to product details and back to dashboard', () => {
+    // Step 1: Go to the landing page
+    cy.visit('/');
+
+    // Step 2: Click any product
+    cy.get('[data-testid="product-card"]').first().click();
+
+    // Step 3: Assert that the product screen is open
+    cy.url().should('include', '/product/');
+    cy.get('[data-testid="product-details"]').should('be.visible');
+
+    // Step 4: Click "dashboard" button
+    cy.get('[data-testid="dashboard-button"]').click();
+
+    // Step 5: Assert that the "Supply Chain Dashboard" screen is open
+    cy.url().should('eq', Cypress.config().baseUrl + '/');
+    cy.get('[data-testid="dashboard-screen"]').should('be.visible');
+  });
+});


### PR DESCRIPTION
Created a new Cypress E2E test file `frontend/cypress/e2e/product-navigation.cy.ts` to validate the following scenario:
1. Go to the landing page
2. Click any product
3. Assert that the product screen is open
4. Click "dashboard" button
5. Assert that the "Supply Chain Dashboard" screen is open

Encountered issues while trying to update components with `data-testid` attributes. The updates were not successful because the old content was not found or empty.