### PR TITLE
Add test for navigating to product details and then to dashboard

### DIFF
--- a/frontend/cypress/e2e/product-navigation.cy.ts
+++ b/frontend/cypress/e2e/product-navigation.cy.ts
@@ -3,7 +3,7 @@ describe('Product Navigation', () => {
     cy.visit('/')
   })
 
-  it('should navigate to product details when clicking a product', () => {
+  it('should navigate to product details when clicking a product and then go to dashboard', () => {
     // Click the first product in the list
     cy.get('[data-testid="product-item"]').first().click()
     
@@ -12,5 +12,14 @@ describe('Product Navigation', () => {
     
     // Verify product details are displayed
     cy.get('[data-testid="product-details"]').should('be.visible')
+
+    // Click the dashboard button
+    cy.get('[data-testid="dashboard-button"]').click()
+
+    // Verify we're on the dashboard page
+    cy.url().should('include', '/dashboard')
+    
+    // Verify dashboard is displayed
+    cy.get('[data-testid="dashboard-page"]').should('be.visible')
   })
 }) 


### PR DESCRIPTION
Implemented a new test case in the product-navigation.cy.ts file to cover the scenario of navigating to a product's details and then to the dashboard.

closes #5