### PR TITLE
Add test for navigating to dashboard from product details

### DIFF
--- a/frontend/cypress/e2e/product-navigation.cy.ts
+++ b/frontend/cypress/e2e/product-navigation.cy.ts
@@ -3,6 +3,26 @@ describe('Product Navigation', () => {
     cy.visit('/')
   })
 
+  it('should navigate to dashboard from product details', () => {
+    // Click the first product in the list
+    cy.get('[data-testid="product-item"]').first().click()
+    
+    // Verify we're on the product details page
+    cy.url().should('include', '/product/')
+    
+    // Verify product details are displayed
+    cy.get('[data-testid="product-details"]').should('be.visible')
+
+    // Click the dashboard button
+    cy.get('[data-testid="dashboard-button"]').click()
+
+    // Verify we're on the dashboard page
+    cy.url().should('eq', Cypress.config().baseUrl + '/')
+    
+    // Verify dashboard is displayed
+    cy.contains('Supply Chain Dashboard').should('be.visible')
+  })
+
   it('should navigate to product details when clicking a product', () => {
     // Click the first product in the list
     cy.get('[data-testid="product-item"]').first().click()
@@ -13,4 +33,44 @@ describe('Product Navigation', () => {
     // Verify product details are displayed
     cy.get('[data-testid="product-details"]').should('be.visible')
   })
-}) 
+
+  it('should navigate to dashboard from product details', () => {
+    // Click the first product in the list
+    cy.get('[data-testid="product-item"]').first().click()
+    
+    // Verify we're on the product details page
+    cy.url().should('include', '/product/')
+    
+    // Verify product details are displayed
+    cy.get('[data-testid="product-details"]').should('be.visible')
+
+    // Click the dashboard button
+    cy.get('[data-testid="dashboard-button"]').click()
+
+    // Verify we're on the dashboard page
+    cy.url().should('eq', Cypress.config().baseUrl + '/')
+    
+    // Verify dashboard is displayed
+    cy.contains('Supply Chain Dashboard').should('be.visible')
+  })
+})
+
+  it('should navigate to dashboard from product details', () => {
+    // Click the first product in the list
+    cy.get('[data-testid="product-item"]').first().click()
+    
+    // Verify we're on the product details page
+    cy.url().should('include', '/product/')
+    
+    // Verify product details are displayed
+    cy.get('[data-testid="product-details"]').should('be.visible')
+
+    // Click the dashboard button
+    cy.get('[data-testid="dashboard-button"]').click()
+
+    // Verify we're on the dashboard page
+    cy.url().should('eq', Cypress.config().baseUrl + '/')
+    
+    // Verify dashboard is displayed
+    cy.contains('Supply Chain Dashboard').should('be.visible')
+  }) 

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -60,7 +60,8 @@ const Navigation: React.FC = () => {
           <Button 
             color="inherit" 
             startIcon={<HomeIcon data-testid="HomeIcon" />}
-            onClick={() => navigate('/')}
+            onClick={() => navigate('/')} 
+            data-testid="dashboard-button"
             sx={{ 
               mx: 1,
               borderRadius: '8px',


### PR DESCRIPTION
Added a Cypress test to verify that the user can navigate to the dashboard from the product details page.

Updated files:
- frontend/src/components/Navigation.tsx
- frontend/cypress/e2e/product-navigation.cy.ts