### PR TITLE
Add Product Dashboard Navigation Test

### DIFF
--- a/frontend/cypress/e2e/product-dashboard-navigation.cy.ts
+++ b/frontend/cypress/e2e/product-dashboard-navigation.cy.ts
@@ -1,0 +1,22 @@
+describe('Product Dashboard Navigation', () => {
+  beforeEach(() => {
+    cy.visit('/')
+  })
+
+  it('should navigate to product details and then to dashboard', () => {
+    // Click the first product in the list
+    cy.get('[data-testid="product-item"]').first().click()
+    
+    // Verify we're on the product details page
+    cy.url().should('include', '/product/')
+    
+    // Verify product details are displayed
+    cy.get('[data-testid="product-details"]').should('be.visible')
+
+    // Click the dashboard button
+    cy.get('[data-testid="dashboard-button"]').click()
+
+    // Verify we're on the dashboard page
+    cy.contains('Supply Chain Dashboard').should('be.visible')
+  })
+})

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -60,7 +60,8 @@ const Navigation: React.FC = () => {
           <Button 
             color="inherit" 
             startIcon={<HomeIcon data-testid="HomeIcon" />}
-            onClick={() => navigate('/')}
+            onClick={() => navigate('/')} 
+            data-testid="dashboard-button"
             sx={{ 
               mx: 1,
               borderRadius: '8px',


### PR DESCRIPTION
Implemented a Cypress E2E test to validate the navigation from the landing page to a product details page and then back to the dashboard.

- Created a new test file: frontend/cypress/e2e/product-dashboard-navigation.cy.ts
- Added data-testid locator to the dashboard button in frontend/src/components/Navigation.tsx

This ensures that the navigation flow works correctly and the respective screens are displayed as expected.