### PR TITLE
Add Product Dashboard Navigation Test

### DIFF
--- a/frontend/cypress/e2e/product-navigation.cy.ts
+++ b/frontend/cypress/e2e/product-navigation.cy.ts
@@ -3,7 +3,7 @@ describe('Product Navigation', () => {
     cy.visit('/')
   })
 
-  it('should navigate to product details when clicking a product', () => {
+  it('should navigate to product details and then to dashboard', () => {
     // Click the first product in the list
     cy.get('[data-testid="product-item"]').first().click()
     
@@ -12,5 +12,14 @@ describe('Product Navigation', () => {
     
     // Verify product details are displayed
     cy.get('[data-testid="product-details"]').should('be.visible')
+    
+    // Click the dashboard button
+    cy.get('[data-testid="HomeIcon"]').click()
+    
+    // Verify we're on the dashboard page
+    cy.url().should('eq', Cypress.config().baseUrl + '/')
+    
+    // Verify dashboard is displayed
+    cy.contains('Supply Chain Dashboard').should('be.visible')
   })
 }) 


### PR DESCRIPTION
Implemented a new Cypress E2E test to validate the navigation from the product details page to the dashboard. This test ensures that the user can navigate from the product details page back to the dashboard and verifies the visibility of the dashboard screen.